### PR TITLE
SHA format invalid on Windows

### DIFF
--- a/lib/jekyll/git_metadata/generator.rb
+++ b/lib/jekyll/git_metadata/generator.rb
@@ -53,7 +53,7 @@ module Jekyll
       end
 
       def lines(file = nil)
-        cmd = "git log --numstat --format='%h'"
+        cmd = "git log --numstat --format=%h"
         cmd << " -- #{file}" if file
         result = %x{ #{cmd} }
         results = result.scan(/(.*)\n\n((?:.*\t.*\t.*\n)*)/)


### PR DESCRIPTION
When calling `git log`, the format was set to `'%h'` which printed the SHA surrounded by single quotes, e.g. `'c665097'`. The regex would pick this up as the actual SHA, and try to pass it to `git show`. This works fine on OS X (I guess the shell is handling the quotes), but fails on Windows with an invalid format error. This change removes the single quotes. Tested on Windows and OS X.
