### PR TITLE
files_count working on Windows

### DIFF
--- a/lib/jekyll/git_metadata/generator.rb
+++ b/lib/jekyll/git_metadata/generator.rb
@@ -95,7 +95,7 @@ module Jekyll
       end
 
       def files_count
-        %x{ git ls-tree -r HEAD | wc -l }.strip.to_i
+        %x{ git ls-tree -r HEAD }.lines.count
       end
 
       def git_installed?


### PR DESCRIPTION
The `files_count` method requires `wc` which isn't available on Windows. Changed to return the number of lines from ruby.
