### PR TITLE
Jekyll 3 changes and fix for getting authors when not running from an interactive shell

### DIFF
--- a/jekyll-git_metadata.gemspec
+++ b/jekyll-git_metadata.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", '~> 2.0'
+  spec.add_dependency "jekyll", '~> 3.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/jekyll/git_metadata/generator.rb
+++ b/lib/jekyll/git_metadata/generator.rb
@@ -12,7 +12,12 @@ module Jekyll
         Dir.chdir(site.source) do
           site.config['git'] = site_data
           (site.pages + site.posts.docs).each do |page|
-            page.data['git'] = page_data(page.path)
+            if page.is_a?(Jekyll::Page)
+              myUrl = page.path
+            else
+              myUrl = page.relative_path
+            end
+            page.data['git'] = page_data(myUrl)
           end
         end
         

--- a/lib/jekyll/git_metadata/generator.rb
+++ b/lib/jekyll/git_metadata/generator.rb
@@ -11,7 +11,7 @@ module Jekyll
 
         Dir.chdir(site.source) do
           site.config['git'] = site_data
-          (site.pages + site.posts).each do |page|
+          (site.pages + site.posts.docs).each do |page|
             page.data['git'] = page_data(page.path)
           end
         end
@@ -42,7 +42,7 @@ module Jekyll
 
       def authors(file = nil)
         results = []
-        cmd = 'git shortlog -se'
+        cmd = 'git shortlog -se HEAD'
         cmd << " -- #{file}" if file
         result = %x{ #{cmd} }
         result.lines.each do |line|

--- a/lib/jekyll/git_metadata/version.rb
+++ b/lib/jekyll/git_metadata/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module GitMetadata
-    VERSION = "0.0.3"
+    VERSION = "0.0.4"
   end
 end


### PR DESCRIPTION
- In Jekyll 3, need to call:
  site.posts.docs instead of site.posts, otherwise this deprication
  warning will be emitted:
  Jekyll.logger.warn "Deprecation:", "Collection##{method} should be
  called on the #docs array directly."

See: jekyll-3.0.0/lib/jekyll/collection.rb
- When running `git shortlog -se` in a none interactive way, [i.e from a jekyll process launched with jekyll serve -P80 -H0.0.0.0  --watch, for example], one would get ENOTTY
  errors and it will not return data, specifying 'HEAD' solves that and it
  then works from both an interactive shell and from the jekyll lunched as
  described above.
