### PR TITLE
Cache git metadata

### DIFF
--- a/lib/jekyll/git_metadata/generator.rb
+++ b/lib/jekyll/git_metadata/generator.rb
@@ -10,23 +10,52 @@ module Jekyll
         raise "Git is not installed" unless git_installed?
 
         Dir.chdir(site.source) do
-          site.config['git'] = site_data
+
+          data = load_git_metadata(site)
+          site.config['git'] = data['site_data']
           (site.pages + site.posts.docs).each do |page|
             if page.is_a?(Jekyll::Page)
               path = page.path
             else
               path = page.relative_path
             end
-            page.data['git'] = page_data(path)
+            page.data['git'] = data['pages_data'][path]
           end
         end
+      end
 
+      def load_git_metadata(site)
+
+        current_sha = %x{ git rev-parse HEAD }.strip
+
+        cache_dir = site.source + '/.git-metadata'
+        FileUtils.mkdir_p(cache_dir) unless File.directory?(cache_dir)
+        cache_file = cache_dir + "/#{current_sha}.json"
+
+        if File.exist?(cache_file)
+          return JSON.parse(IO.read(cache_file))
+        end
+
+        pages_data = {}
+        (site.pages + site.posts.docs).each do |page|
+          if page.is_a?(Jekyll::Page)
+            path = page.path
+          else
+            path = page.relative_path
+          end
+          pages_data[path] = page_data(path)
+        end
+        data = { 'site_data' => site_data, 'pages_data' => pages_data }
+
+        File.open(cache_file, 'w') { |f| f.write(data.to_json) }
+
+        data
       end
 
       def site_data
         {
           'project_name' => project_name,
-          'files_count' => files_count
+          'files_count' => files_count,
         }.merge!(page_data)
       end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,11 +5,15 @@ require 'mocha/mini_test'
 require 'jekyll'
 require 'jekyll-git_metadata'
 
-class Minitest::Test
-  def jekyll_test_repo_path
-    File.join(File.dirname(__FILE__), 'test_repo')
-  end
+def jekyll_test_repo_path
+  File.join(File.dirname(__FILE__), 'test_repo')
+end
 
+def remove_cache_dir
+  FileUtils.rm_rf(File.join(jekyll_test_repo_path, '.git-metadata'))
+end
+
+class Minitest::Test
   def dot_git_path
     File.join(jekyll_test_repo_path, 'dot_git')
   end

--- a/test/test_git_metadata.rb
+++ b/test/test_git_metadata.rb
@@ -1,5 +1,9 @@
 require 'helper'
 
+Minitest.after_run do
+  remove_cache_dir
+end
+
 class Jekyll::GitMetadataTest < Minitest::Test
   context 'GitMetadata' do
 


### PR DESCRIPTION
Saves and loads the git metadata to a local cache file. Makes it a lot quicker to regenerate the site when a single file changes, while still maintaining git metadata.