### PR TITLE
updated Gemfile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Expose Git metadata to Jekyll. Just like how Github exposes [repository metadata
 Add to your `Gemfile`:
 
 ```
-gem 'jekyll-git_metadata'
+gem 'jekyll-git_metadata, group: :jekyll_plugins'
 ```
 
 Add to your `_config.yml`:


### PR DESCRIPTION
Maybe I am wrong, but I can only get my site to build if I add the `jekyll_plugin` group to the `jekyll-git_metadata` entry in my Gemfile.